### PR TITLE
main file name fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     }
   ]
 , "dependencies": { "socket.io": ">=1.3.*" }
-, "main": "./lib/simple-telegram.js"
+, "main": "./lib/simpletelegram.js"
 }


### PR DESCRIPTION
The main js file wasn't correctly spelled in the package.json.

To avoid Error: Cannot find module 'simple-telegram' simply remove the dash in package.json

A temporary workaround may also be requiring such file directly instead of requiring the module:
```javascript
var SimpleTelegram = require('simple-telegram/lib/simpletelegram.js');
```

cheers